### PR TITLE
Bug fix for issue #6 - (Py2 to Py3 Hmac) opened by @araa47

### DIFF
--- a/python/Gateio.py
+++ b/python/Gateio.py
@@ -10,8 +10,8 @@ import base64
 import hashlib
 
 def get_sign(secret_key, message):
-	h = hmac.new(secret_key, message, hashlib.sha512)
-	return base64.b64encode(h.digest())
+	h = (base64.b64encode(hmac.new(secret_key.encode('utf-8'), message.encode('utf-8'), hashlib.sha512).digest())).decode()
+	return h
 
 class GateWs:
 	def __init__(self, url, apiKey, secretKey):


### PR DESCRIPTION
My bug fix addresses the issue brought up by @araa47 which causes what I believe is a critical break in functionality for python3 developers. The bug essentially breaks Auth for python3 developers by breaking the get_sign function needed to generate a signature required to authenticate. Python2 I believe is EOL since January 1st, 2020, so I believe this fix adds tremendous value to this project. 