### PR TITLE
Bump json5 and config in /nodejs

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -81,11 +81,11 @@
       }
     },
     "config": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/config/-/config-1.31.0.tgz",
-      "integrity": "sha512-Ep/l9Rd1J9IPueztJfpbOqVzuKHQh4ZODMNt9xqTYdBBNRXbV4oTu34kCkkfdRVcDq0ohtpaeXGgb+c0LQxFRA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.3.8.tgz",
+      "integrity": "sha512-rFzF6VESOdp7wAXFlB9IOZI4ouL05g3A03v2eRcTHj2JBQaTNJ40zhAUl5wRbWHqLZ+uqp/7OE0BWWtAVgrong==",
       "requires": {
-        "json5": "1.0.1"
+        "json5": "^2.2.1"
       }
     },
     "core-util-is": {
@@ -225,12 +225,9 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "requires": {
-        "minimist": "1.2.0"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -255,11 +252,6 @@
       "requires": {
         "mime-db": "1.35.0"
       }
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "moment": {
       "version": "2.22.2",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "bluebird": "^3.3.1",
-    "config": "^1.28.1",
+    "config": "^3.3.8",
     "crypto-js": "^3.1.9-1",
     "moment": "^2.13.0",
     "pako": "^1.0.6",


### PR DESCRIPTION
Bumps [json5](https://github.com/json5/json5) to 2.2.3 and updates ancestor dependency [config](https://github.com/node-config/node-config). These dependencies need to be updated together.


Updates `json5` from 1.0.1 to 2.2.3
- [Release notes](https://github.com/json5/json5/releases)
- [Changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md)
- [Commits](https://github.com/json5/json5/compare/v1.0.1...v2.2.3)

Updates `config` from 1.31.0 to 3.3.8
- [Release notes](https://github.com/node-config/node-config/releases)
- [Changelog](https://github.com/node-config/node-config/blob/master/History.md)
- [Commits](https://github.com/node-config/node-config/commits/v3.3.8)

---
updated-dependencies:
- dependency-name: json5 dependency-type: indirect
- dependency-name: config dependency-type: direct:production ...